### PR TITLE
Bugfix/troubleshooting web qr revert correction

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,6 +66,9 @@ class _MyAppState extends State<MyApp> {
             Container(
               width: 640,
               height: 480,
+
+              /// !IMPORTANT: This widget needs to be bound in a sized box or other container
+              /// Other Flutter throws unbound render flex hit test errors
               child: QRolo(),
             ),
             SizedBox(height: 640, width: 480)

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -30,6 +30,9 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <!-- ! IMPORTANT: Add jsQR for use in web -->
+  <script src="https://cdn.jsdelivr.net/npm/jsqr@1.3.1/dist/jsQR.min.js"></script>
+
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->

--- a/lib/qrolo.dart
+++ b/lib/qrolo.dart
@@ -33,6 +33,8 @@ import 'package:qrolo/src/media.dart';
 const int defaultScanIntervalMilliseconds = 500;
 
 /// The QRolo scanner widget
+/// !IMPORTANT: This widget needs to be bound in a sized box or other container
+/// Other Flutter throws unbound render flex hit test errors
 class QRolo extends StatefulWidget {
   /// clickToCapture to show a button to capture a Data URL for the image
   final bool clickToCapture;

--- a/lib/qrolo.dart
+++ b/lib/qrolo.dart
@@ -6,9 +6,11 @@ import 'dart:html' as html
         DivElement,
         DomException,
         ImageData,
+        MediaRecorder,
         MediaStream,
         VideoElement,
         window;
+import 'dart:js_util';
 import 'dart:typed_data';
 // dart:ui is valid use import platformViewRegistry
 // https://github.com/flutter/flutter/issues/41563
@@ -25,10 +27,18 @@ import 'package:qrolo/src/html/media/utilities/is_media_device_camera_available.
     show isCameraAvailableInMediaDevices;
 import 'package:qrolo/src/jsqr.dart' show jsQR;
 
+import 'package:js/js.dart' show JS, anonymous;
+import 'package:qrolo/src/media.dart';
+
 const int defaultScanIntervalMilliseconds = 500;
 
 /// The QRolo scanner widget
 class QRolo extends StatefulWidget {
+  /// clickToCapture to show a button to capture a Data URL for the image
+  final bool clickToCapture;
+
+  const QRolo({this.clickToCapture = false, Key? key}) : super(key: key);
+
   @override
   _QRoloState createState() => _QRoloState();
 
@@ -36,467 +46,257 @@ class QRolo extends StatefulWidget {
 
   static Future<String?> get platformVersion async {
     final version = await _channel.invokeMethod<String>('getPlatformVersion');
-
-    return version;
   }
 
-  /// Whether to show the camera button overlaid on scanner video stream view
-  /// Maybe this should be split into two separate widgets for fulfilling
-  /// Two distinct purposes
-  ///
-  /// clean code distinct paths
-  ///
-  /// Or root-level bool toggle with discrete discriminated widget builder fns
-  final bool isClickToCaptureEnabled;
+  static html.DivElement vidDiv =
+      html.DivElement(); // need a global for the registerViewFactory
 
-  const QRolo({
-    Key? key,
-    this.isClickToCaptureEnabled = false,
-  }) : super(key: key);
-
-  /// Utility to reference the html div to add a video element to
-  /// the children of div element
-  ///
-  /// ?
-  /// need a global for the registerViewFactory
-  /// when initialising state initState
-  /// ui.platformViewRegistry.registerViewFactory
-  static final html.DivElement videoDiv = html.DivElement();
-
-  static Future<bool> isCameraAvailable() async =>
-      isCameraAvailableInMediaDevices();
+  static Future<bool> cameraAvailable() async {
+    List<dynamic> sources =
+        await html.window.navigator.mediaDevices!.enumerateDevices();
+    print("sources:");
+    // List<String> vidIds = [];
+    bool hasCam = false;
+    for (final e in sources) {
+      print(e);
+      if (e.kind == 'videoinput') {
+        // vidIds.add(e['deviceId']);
+        hasCam = true;
+      }
+    }
+    return hasCam;
+  }
 }
 
 class _QRoloState extends State<QRolo> {
-  html.MediaStream? _cameraStream;
-
-  ///
-  /// @example
-  /// "NotFoundError: Requested device not found"
-  /// Indicates error on getUserMedia()
-  String? _errorMessage;
-  String viewFactoryDivViewID = 'qrolo-scanner-view';
-  late html.VideoElement videoElement;
-  // Make hook to exit on first scan found and stop loops.
-
-  @override
-  Widget build(BuildContext context) {
-    if (_errorMessage != null) {
-      return Center(child: Text(_errorMessage!));
-    }
-    if (_cameraStream == null) {
-      // Quick in-place loading message
-      // Is it better design to expose hooks and let
-      // the calling developer supply their own loading widgets?
-
-      return const Text('Loading...');
-    }
-
-    return Column(
-      children: [
-        Expanded(
-          child: OrientationBuilder(
-            builder: (BuildContext context, Orientation orientation) {
-              return Center(
-                child: Container(
-                  margin: const EdgeInsets.all(0),
-                  decoration: const BoxDecoration(color: Colors.black54),
-                  child: HtmlElementView(
-                    viewType: viewFactoryDivViewID,
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
-    );
-  }
+  html.MediaStream? _localStream;
+  // html.CanvasElement canvas;
+  // html.CanvasRenderingContext2D ctx;
+  bool _inCalling = false;
+  bool _isTorchOn = false;
+  html.MediaRecorder? _mediaRecorder;
+  bool get _isRec => _mediaRecorder != null;
+  Timer? timer;
+  String? code;
+  String? _errorMsg;
+  var front = false;
+  html.VideoElement? video;
+  String viewID = "your-view-id";
 
   @override
   void initState() {
+    print("MY SCANNER initState");
     super.initState();
-    debugPrint('QRolo scanner init');
-
-    // Create new VideoElement and add to view factory div
-    videoElement = html.VideoElement();
-    QRolo.videoDiv.children = [videoElement];
-
-    // This is valid usage on build
-    // Dev analyzer has not been updated to accept this yet.
-    // ignore: undefined_prefixed_name
-    ui.platformViewRegistry.registerViewFactory(
-      viewFactoryDivViewID,
-      (int id) => QRolo.videoDiv,
-    );
-
-    scanStream();
+    video = html.VideoElement();
+    // canvas = new html.CanvasElement(width: );
+    // ctx = canvas.context2D;
+    QRolo.vidDiv.children = [video!];
+    // ignore: UNDEFINED_PREFIXED_NAME
+    ui.platformViewRegistry
+        .registerViewFactory(viewID, (int id) => QRolo.vidDiv);
+    // initRenderers();
+    Timer(Duration(milliseconds: 500), () {
+      start();
+    });
   }
 
-  /// Methods should not be exposed
-  /// Maybe wrap this into the _web-only implementation as well
-  void startContinuousScanningLoop({
-    int scanIntervalMs = defaultScanIntervalMilliseconds,
-  }) {
-    /*
-      1. Start camera media stream
-        a. If null unable to capture then try again or error feedback dev/user
-      2. Play (add to video element)
-      3. Capture compare qr code (loop)
-    */
-    // - FIXME: Do not need to re-call once the reference is available
-    // Parts of the nested code flow should only be called once then...
-
-    Timer(
-      Duration(
-        milliseconds: scanIntervalMs,
-      ),
-      () {
-        scanStream();
-      },
-    );
-  }
-
-  Future<String?> scanStream() async {
-    // 1. Start camera stream and get back
-    final videoStream = await callPlatformOpenMediaVideoStream();
-
-    if (videoStream == null) {
-      //
-      debugPrint('Error accessing camera stream getUserMedia()');
-
-      return null;
+  void start() async {
+    await _makeCall();
+    // if (timer == null || !timer.isActive) {
+    //   timer = Timer.periodic(Duration(milliseconds: 500), (timer) {
+    //     if (code != null) {
+    //       timer.cancel();
+    //       Navigator.pop(context, code);
+    //       return;
+    //     }
+    //     _captureFrame2();
+    //     if (code != null) {
+    //       timer.cancel();
+    //       Navigator.pop(context, code);
+    //     }
+    //   });
+    // }
+    if (!widget.clickToCapture) {
+      // instead of periodic, which seems to have some timing issues, going to call timer AFTER the capture.
+      Timer(Duration(milliseconds: 200), () {
+        _captureFrame2();
+      });
     }
-    // Not assigned directly to allow local context null discrimination check
-    // Otherwise technically the _cameraStream could be nulled right before use
-    _cameraStream = videoStream;
+  }
 
-    // 1. a. Present the stream
-    final dynamic? playResult = await startPlayingStream(
-      videoStream,
-      videoElement,
-    );
-    debugPrint(playResult?.toString());
+  void cancel() {
+    if (timer != null) {
+      timer!.cancel();
+      timer = null;
+    }
+    if (_inCalling) {
+      _stopStream();
+    }
+  }
 
-    // 2. Capture frame from the currently running stream
-    // Current stream reference should be available
-    // Periodically obtain rather than making a call each time
-    // Performance
-    // FP
-    // Assuming width and height data are flutter virtual int pixel size
-    // Otherwise it will mess up qr code data matrix
+  @override
+  void dispose() {
+    print("Scanner.dispose");
+    cancel();
+    super.dispose();
+  }
 
-    // Use the same video height and width
-    // on virtual canvas and the matrix jsQR check
-    // ASssuming videoElement set up well. No edge null cases
-    final int width = videoElement.videoWidth;
-    final int height = videoElement.videoHeight;
-
-    final html.ImageData imageData = captureFrameFromStream(videoElement);
-
-    /* 
-    if (imageData == null) {
+  // Platform messages are asynchronous, so we initialize in an async method.
+  Future<void> _makeCall() async {
+    if (_localStream != null) {
       return;
     }
-    */
 
-    // 3. Compare frame (calculate QR algo) and get code back
-    final String? qrCode = getQRCodeFromImageDataFrame(
-      imageData,
-      width,
-      height,
-    );
-
-    if (qrCode == null) {
-      // No QR code from this specific frame
-
-    }
-
-    return qrCode;
-
-    // Catch DOMException
-    // drawImage()
-    //  INDEX_SIZE
-    //  INVALID_STATE
-    //  TYPE_MISMATCH
-    //  NAMESPACE ?? NS_ERROR_NOT_AVAILABLE image not loaded.. .complete .onload
-    //
-    // imageData
-    // INDEX_SIZE
-    // SECURITY
-  }
-
-  /// Try to get the stream
-  ///
-  /// Assume async platform call will not race against the scan interval
-  /// Configure getUserMedia video stream
-  /// add stream source to our video element with config
-  ///  - playsinline
-  ///  - 'true' non fullscreen
-  ///
-  /// Then finally trigger the HTMLVideoelement.play HTMLMediaElement play()
-  /// Returns rejected promise if playback cannot be started
-  Future<html.MediaStream?> callPlatformOpenMediaVideoStream() async {
     try {
-      /*
-      final Map<String, Object> exampleVideoConstraintsOptions = {
-        'mandatory': {'minAspectRatio': 1.333, 'maxAspectRatio': 1.334},
-        'optional': [
-          {'minFrameRate': 60},
-          {'maxWidth': 640}
-        ]
-      };
-      */
-      const Map<String, Object> videoConstraints = {
-        'facingMode': 'environment',
-      };
+      var constraints = UserMediaOptions(
+          // audio: false,
+          video: VideoOptions(
+        facingMode: (front ? "user" : "environment"),
+      ));
+      // dart style, not working properly:
+      // var stream =
+      //     await html.window.navigator.mediaDevices.getUserMedia(constraints);
+      // straight JS:
+      final stream =
+          await promiseToFuture<html.MediaStream>(getUserMedia(constraints));
+      _localStream = stream;
+      video?.srcObject = _localStream;
+      video?.setAttribute("playsinline",
+          'true'); // required to tell iOS safari we don't want fullscreen
+      final dynamic playTest = await video?.play();
+    } catch (e) {
+      print("error on getUserMedia: ${e.toString()}");
+      cancel();
+      setState(() {
+        _errorMsg = e.toString();
+      });
+      return;
+    }
+    if (!mounted) return;
 
-      final html.MediaStream? mediaStream =
-          // ignore: unnecessary_cast
-          await html.window.navigator.getUserMedia(
-        video: videoConstraints,
-      ) as html.MediaStream?;
+    setState(() {
+      _inCalling = true;
+    });
+  }
 
-      if (mediaStream == null) {
-        // This should not occur
-        // Should catch DomException rather than return null
+  void _hangUp() async {
+    await _stopStream();
+    setState(() {
+      _inCalling = false;
+    });
+  }
 
-        // // e.g. Error: NotFoundError: Requested device not found
-        // We do not receive the extra error info here
-        // Need to use custom JS interop to expose more error info.
-        // "NotFoundError: Requested device not found"
-        // Indicates error on getUserMedia()
-        const String message = 'No camera access found: '
-            'Please check camera device/permission';
-
-        _updateErrorMessage(message);
-
-        return null;
-      }
-
-      return mediaStream;
-    } on html.DomException catch (domException, stackTrace) {
-      // Code actually breaks out exception rather than returning null
-
-      _updateErrorMessage(
-        'Unable to access camera stream \n'
-        'Please check camera devices/permissions \n'
-        'DOM Exception ${domException.toString()} ${stackTrace.toString()}',
-      );
-
-      return null;
-    } on Exception catch (e, stackTrace) {
-      _updateErrorMessage(
-        'Unable to access camera stream getUserMedia(): '
-        'Exception: ${e.toString()} ${stackTrace.toString()}',
-      );
-
-      return null;
-      // ignore: avoid_catches_without_on_clauses
-    } catch (e, stackTrace) {
-      // This should not occur
-      _updateErrorMessage(
-        'Unable to access camera stream errors: '
-        '${e.toString()} ${stackTrace.toString()}',
-      );
-
-      return null;
+  Future<void> _stopStream() async {
+    try {
+      // await _localStream.dispose();
+      _localStream!.getTracks().forEach((track) {
+        if (track.readyState == 'live') {
+          track.stop();
+        }
+      });
+      // video.stop();
+      video?.srcObject = null;
+      _localStream = null;
+      // _localRenderer.srcObject = null;
+    } catch (e) {
+      print(e.toString());
     }
   }
 
-  ///
-  /// Show the captured stream to the user on the page video element src
-  /// Test using https://media-play-promise.glitch.me/
-  /// https://webrtc.github.io/samples/src/video/chrome.mp4
-  /// videoElementToUpdateDirectly.setAttribute(
-  ///   'src',
-  ///   'https://webrtc.github.io/samples/src/video/chrome.mp4',
-  /// );
-  ///
-  /// Error: NotAllowedError: play() failed because the user didn't interact with the document first.
-  /// https://goo.gl/xX8pDD
-  Future<dynamic?> startPlayingStream(
-    html.MediaStream videoStream,
-    html.VideoElement videoElementToUpdateDirectly,
-  ) async {
-    // Mutate
-    // Present the media stream on the HTMLVideoElement
-    videoElementToUpdateDirectly.srcObject = videoStream;
-
-    // Explicit inline the video within widget.
-    // iOS Safari would expand fullscreen automatically once playback begins.
-    // Check iOS versions
-    // https://webkit.org/blog/6784/new-video-policies-for-ios/
-    videoElementToUpdateDirectly.setAttribute('playsinline', 'true');
-
-    // Possible returns
-    // NotAllowedError (user agent, OS)
-    // NotSupportedError (an unsupported MediaStream source blob file format)
-    // Automatic vs user press.
-    //
-    // Could be JS undefined?
-    // Example
-    // Error: NotAllowedError: play() failed because the user didn't interact with the document first.
-    // https://goo.gl/xX8pDD
-    final dynamic? playResult = await videoElementToUpdateDirectly.play();
-
-    return playResult;
+  void _toggleCamera() async {
+    final videoTrack = _localStream!
+        .getVideoTracks()
+        .firstWhere((track) => track.kind == 'video');
+    // await videoTrack.switchCamera();
+    videoTrack.stop();
+    await _makeCall();
   }
 
-  /// Draw a virtual canvas to get the image data back..
-  /// videoElement `HTMLVideoElement` can be used as a `CanvasImageSource`
-  /// Use frames being presented by a <video> element
-  /// even if not visible
-
-  /// Surely there is a quicker version?
-  ///
-  /// Get the image data or matrix from our streaming video element
-  ///
-  /// Important: width and heigth should match across video, image, jsqr data
-  ///
-  /// ? Warning: Unsure if canvas video div element may have been potentially
-  /// mutated by devor dynamic user responsive UI
-  html.ImageData captureFrameFromStream(
-    html.VideoElement videoElement,
-  ) {
-    // Creating a virtual canvas simply to capture imageData?
-    final html.CanvasElement sizedDrawnCanvasContextualisedFrame =
-        createPredrawnCanvasFrameContextFromVideoElement(
-            videoElement: videoElement);
-
-    // Seems superfluous to do this just to get imageData
-    // Though lots of canvas utility
-    const int topLeftDestXLeft = 0;
-    const int topLeftDestYTop = 0;
-
-    final html.ImageData imageData =
-        sizedDrawnCanvasContextualisedFrame.context2D.getImageData(
-      topLeftDestXLeft,
-      topLeftDestYTop,
-      videoElement.width,
-      videoElement.height,
-    );
-
-    /* 
-      IndexSizeError
-      SecurityError
-     */
-    return imageData;
+  Future<dynamic> _captureFrame2() async {
+    if (_localStream == null) {
+      print("localstream is null, can't capture frame");
+      return null;
+    }
+    html.CanvasElement canvas = new html.CanvasElement(
+        width: video?.videoWidth, height: video?.videoHeight);
+    html.CanvasRenderingContext2D ctx = canvas.context2D;
+    // canvas.width = video.videoWidth;
+    // canvas.height = video.videoHeight;
+    ctx.drawImage(video!, 0, 0);
+    html.ImageData imgData =
+        ctx.getImageData(0, 0, canvas.width!, canvas.height!);
+    // print(imgData);
+    var code = jsQR(imgData.data, canvas.width!, canvas.height!);
+    // print("CODE: $code");
+    if (code != null) {
+      print(code.data);
+      this.code = code.data;
+      Navigator.pop(context, this.code);
+      return this.code;
+    } else {
+      Timer(Duration(milliseconds: 500), () {
+        _captureFrame2();
+      });
+    }
   }
 
-  /// Utility function
-  /// To reuse for both capture frame image data
-  /// and convert canvas (with context drawn) ito dataURI dataUrl
-  html.CanvasElement createPredrawnCanvasFrameContextFromVideoElement({
-    required html.VideoElement videoElement,
-    int topLeftDestXLeft = 0,
-    int topLeftDestYTop = 0,
-  }) {
-    // Creating a virtual canvas simply to draw + capture imageData?
-    final html.CanvasElement sizedVideoCanvas = html.CanvasElement(
-      width: videoElement.width,
-      height: videoElement.height,
-    );
-    final html.CanvasRenderingContext2D context = sizedVideoCanvas.context2D;
-
-    // `HTMLVideoElement` can be used as a `CanvasImageSource`
-    // Use frames being presented by a <video> element
-    // even if not visible
-    context.drawImage(
-      videoElement,
-      topLeftDestXLeft,
-      topLeftDestYTop,
-    );
-
-    return sizedVideoCanvas;
+  Future<String?> _captureImage() async {
+    if (_localStream == null) {
+      print("localstream is null, can't capture frame");
+      return null;
+    }
+    html.CanvasElement canvas = new html.CanvasElement(
+        width: video!.videoWidth, height: video!.videoHeight);
+    html.CanvasRenderingContext2D ctx = canvas.context2D;
+    // canvas.width = video.videoWidth;
+    // canvas.height = video.videoHeight;
+    ctx.drawImage(video!, 0, 0);
+    var dataUrl = canvas.toDataUrl("image/jpeg", 0.9);
+    return dataUrl;
   }
 
-  /// API utility for quick saving with the current video
-  /// Blob is faster than dataUrl though
-  ///
-  /// imageDataUrlType
-  ///   - 'image/jpeg'
-  ///   - 'image/png'
-  ///   - 'image/webp'
-  ///
-  /// @returns DOMString
-  String getImageBase64DataUrlFromVideo({
-    required html.VideoElement videoElement,
-    String imageDataUrlType = 'image/jpeg',
-    double qualityDecimalFraction = 0.90,
-    int topLeftDestXLeft = 0,
-    int topLeftDestYTop = 0,
-  }) {
-    final html.CanvasElement frameCanvas =
-        createPredrawnCanvasFrameContextFromVideoElement(
-      videoElement: videoElement,
-    );
-
-    return frameCanvas.toDataUrl(
-      imageDataUrlType,
-      qualityDecimalFraction,
-    );
-  }
-
-  /// Single function call
-  /// minimal additional value other than sensible defaults
-  String getImageBase64DataUrlFromCanvas({
-    required html.CanvasElement predrawnVideoFrameCanvas,
-    String imageDataUrlType = 'image/jpeg',
-    double qualityDecimalFraction = 0.90,
-    int topLeftDestXLeft = 0,
-    int topLeftDestYTop = 0,
-  }) {
-    /// `canvas.toDataUrl("image/jpeg", 0.90);`
-    return predrawnVideoFrameCanvas.toDataUrl(
-      imageDataUrlType,
-      qualityDecimalFraction,
-    );
-  }
-
-  ///
-  /// Assumedly straight 0-255 1D array that is transformed into
-  /// calculation matrix based on width and height
-  ///
-  /// Could ostensibly be used for QR code check of any image data,
-  /// given the right transformation params
-  String? getQRCodeFromData(
-    Uint8ClampedList data,
-    int width,
-    int height,
-  ) {
-    // Use jsQR
-    jsQR(
-      data,
-      width,
-      height,
-    );
-
-    return null;
-  }
-
-  /// Helper wrapper
-  /// for compatibility with MediaStream ImageData
-  String? getQRCodeFromImageDataFrame(
-    html.ImageData image,
-    int width,
-    int height,
-  ) {
-    return getQRCodeFromData(
-      image.data,
-      width,
-      height,
-    );
-  }
-
-  /// Reflect error message in widget state displayed text as well
-  /// Widget conditionally builds depending on error or loading message
-  void _updateErrorMessage(String message) {
-    debugPrint(
-      message,
-    );
-    setState(() {
-      _errorMessage = message;
-    });
+  @override
+  Widget build(BuildContext context) {
+    if (_errorMsg != null) {
+      return Center(child: Text(_errorMsg!));
+    }
+    if (_localStream == null) {
+      return Text("Loading...");
+    }
+    return Column(children: [
+      Expanded(
+        child: Container(
+            // constraints: BoxConstraints(
+            //   maxWidth: 600,
+            //   maxHeight: 1000,
+            // ),
+            child: OrientationBuilder(
+          builder: (context, orientation) {
+            return Center(
+              child: Container(
+                margin: EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 0.0),
+                // width: MediaQuery.of(context).size.width,
+                // height: MediaQuery.of(context).size.height,
+                child: HtmlElementView(viewType: viewID),
+                decoration: BoxDecoration(color: Colors.black54),
+              ),
+            );
+          },
+        )),
+      ),
+      // IconButton(
+      //   icon: Icon(Icons.switch_video),
+      //   onPressed: _toggleCamera,
+      // ),
+      if (widget.clickToCapture)
+        IconButton(
+          icon: Icon(Icons.camera),
+          onPressed: () async {
+            var imgUrl = await _captureImage();
+            print("Image URL: $imgUrl");
+            Navigator.pop(context, imgUrl);
+          },
+        ),
+    ]);
   }
 }

--- a/lib/src/media.dart
+++ b/lib/src/media.dart
@@ -1,0 +1,38 @@
+@JS('navigator.mediaDevices')
+library media_devices;
+
+import 'dart:html' as html show MediaStream;
+
+// This is here because dart doesn't seem to support this properly
+// https://stackoverflow.com/questions/61161135/adding-support-for-navigator-mediadevices-getusermedia-to-dart
+
+import 'package:js/js.dart';
+
+@JS('getUserMedia')
+external Future<html.MediaStream> getUserMedia(UserMediaOptions constraints);
+
+@JS()
+@anonymous
+class UserMediaOptions {
+  external VideoOptions get video;
+
+  external factory UserMediaOptions({VideoOptions? video});
+}
+
+@JS()
+@anonymous
+class VideoOptions {
+  external String get facingMode;
+  // external DeviceIdOptions get deviceId;
+
+  external factory VideoOptions(
+      {String? facingMode, DeviceIdOptions? deviceId});
+}
+
+@JS()
+@anonymous
+class DeviceIdOptions {
+  external String get exact;
+
+  external factory DeviceIdOptions({String? exact});
+}


### PR DESCRIPTION
This should alternatively be merged to feature/implement-web-qr directly 
Gets things to a working state and cleans up some intermediary commits
Imports jQR from CDN in web index.html src


1. Remove incorrect revert (to now re-add the SizedBox to avoid Flutter error unbound render flex _we should alternatively wrap the widget with default w h_)
2. Add the correct revert on the WIP mess (intermediary commit made in rebase).
3. Add the script src for the js library we are using
4. Add the known working code (with minor adjustments for null safety and convention) back
  a. Essentially a huge copy paste file replacement rather than a line diff

Should have the same end result working state commit at b1df0cd77f2275eb273a3e9a02babf81c6192e02 as 3658869d52610df9e09999ae0caddd87a9eadeda

only slight differences i.e. imports


 - TODO: Create a new branch after this (WORKING) one to clearly line-debug (FIXED-WORKING) Merge this as a working state snapshot and then create a new branch for finding the specific issue of undefined video element and video .play width mutation on HTML DOM as it seems other functionality is working


